### PR TITLE
Fix supporting document reference

### DIFF
--- a/job_tracker/app/controllers/supporting_documents_controller.rb
+++ b/job_tracker/app/controllers/supporting_documents_controller.rb
@@ -21,10 +21,22 @@ class SupportingDocumentsController < ApplicationController
 
   # POST /supporting_documents or /supporting_documents.json
   def create
-    @supporting_document = SupportingDocument.new(supporting_document_params)
+    @supporting_document = SupportingDocument.new(
+      name: supporting_document_params[:name],
+      document: supporting_document_params[:document])
+    
 
     respond_to do |format|
       if @supporting_document.save
+
+        valid_ids = supporting_document_params[:job_application_ids].select { |app_id| app_id.blank? == false}
+        valid_ids.each { |id|
+          linker = DocumentLinker.new(
+            job_application_id: id,
+            supporting_document_id: @supporting_document.id)
+          linker.save!
+        }
+
         format.html { redirect_to supporting_document_url(@supporting_document), notice: "Supporting document was successfully created." }
         format.json { render :show, status: :created, location: @supporting_document }
       else
@@ -37,7 +49,17 @@ class SupportingDocumentsController < ApplicationController
   # PATCH/PUT /supporting_documents/1 or /supporting_documents/1.json
   def update
     respond_to do |format|
-      if @supporting_document.update(supporting_document_params)
+      if @supporting_document.update(
+        name: supporting_document_params[:name],
+        document: supporting_document_params[:document])
+
+        valid_ids = supporting_document_params[:job_application_ids].select { |app_id| app_id.blank? == false}
+        valid_ids.each { |id|
+          linker = DocumentLinker.create!(
+            job_application_id: id,
+            supporting_document_id: @supporting_document.id)
+        }
+
         format.html { redirect_to supporting_document_url(@supporting_document), notice: "Supporting document was successfully updated." }
         format.json { render :show, status: :ok, location: @supporting_document }
       else
@@ -65,6 +87,7 @@ class SupportingDocumentsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def supporting_document_params
-      params.require(:supporting_document).permit(:name, :document, :job_application_id)
+
+      params.require(:supporting_document).permit(:name, :document, :job_application_ids => [])
     end
 end

--- a/job_tracker/app/models/document_linker.rb
+++ b/job_tracker/app/models/document_linker.rb
@@ -1,0 +1,6 @@
+class DocumentLinker < ApplicationRecord
+  belongs_to :job_application
+  belongs_to :supporting_document
+
+  validates :job_application, :supporting_document, presence: true
+end

--- a/job_tracker/app/models/job_application.rb
+++ b/job_tracker/app/models/job_application.rb
@@ -1,10 +1,15 @@
 class JobApplication < ApplicationRecord
   belongs_to :employer
   has_one :job_description, dependent: :delete
-  has_many :supporting_documents, dependent: :delete_all
+  has_many :document_linkers, dependent: :destroy
+  has_many :supporting_documents, :through => :document_linkers
   
   accepts_nested_attributes_for :job_description, update_only: true
 
   enum status: %i[applied rejected interview_scheduled second_round waiting_decision offered_job hired].index_with(&:to_s)
+
+  def full_title
+    "#{employer.name}: #{job_title}"
+  end
 
 end

--- a/job_tracker/app/models/supporting_document.rb
+++ b/job_tracker/app/models/supporting_document.rb
@@ -1,6 +1,9 @@
 class SupportingDocument < ApplicationRecord
-  belongs_to :job_application
+  has_many :document_linkers
+  has_many :job_applications, :through => :document_linkers
+
   has_one_attached :document, dependent: :destroy
+
 
   validates :name, :document, presence: true
   validates :name, format: { with: /\A[a-zA-Z\s]+\z/, message: "only allows letters and spaces" }

--- a/job_tracker/app/models/supporting_document.rb
+++ b/job_tracker/app/models/supporting_document.rb
@@ -1,5 +1,5 @@
 class SupportingDocument < ApplicationRecord
-  has_many :document_linkers
+  has_many :document_linkers, dependent: :destroy
   has_many :job_applications, :through => :document_linkers
 
   has_one_attached :document, dependent: :destroy

--- a/job_tracker/app/views/supporting_documents/_form.html.erb
+++ b/job_tracker/app/views/supporting_documents/_form.html.erb
@@ -21,12 +21,13 @@
     <%= form.file_field :document %>
   </div>
 
-  <div>
-    <%= form.label :job_application_id, style: "display: block" %>
-    <%= form.select :job_application_id,
-      JobApplication.all.map { |job_app| [ "#{job_app.employer.name}: #{job_app.job_title}", job_app.id ] },
-      include_blank: true
-    %>
+  <div class="form-group">
+    <%= form.label :job_application_ids, style: "display: block" %>
+    <%= form.collection_check_boxes(:job_application_ids, JobApplication.all, :id, :full_title) do |box| %>
+      <li class="list-unstyled">
+        <%= box.label(:job_application_ids => box.value) { box.check_box + box.text}%>
+      </li>
+    <% end %>
   </div>
 
   <div>

--- a/job_tracker/app/views/supporting_documents/_supporting_document.html.erb
+++ b/job_tracker/app/views/supporting_documents/_supporting_document.html.erb
@@ -5,9 +5,13 @@
   </h2>
 
   <p>
-    <strong>Job application:</strong>
-    <%= link_to "#{supporting_document.job_application.job_title}", job_application_path(supporting_document.job_application) %>
-  </p>
+    <strong>Job applications:</strong>
+    <% supporting_document.job_applications.each do |application|%>
+      <li class="list-unstyled">
+        <%= link_to "#{application.job_title}", job_application_path(application) %>
+      </li>
+    <% end %>
+  </p> 
 
 
   <p>

--- a/job_tracker/db/migrate/20240206231826_create_supporting_documents.rb
+++ b/job_tracker/db/migrate/20240206231826_create_supporting_documents.rb
@@ -2,7 +2,6 @@ class CreateSupportingDocuments < ActiveRecord::Migration[7.1]
   def change
     create_table :supporting_documents, id: :uuid do |t|
       t.string :name
-      t.references :job_application, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/job_tracker/db/migrate/20240220215140_create_document_linkers.rb
+++ b/job_tracker/db/migrate/20240220215140_create_document_linkers.rb
@@ -1,0 +1,10 @@
+class CreateDocumentLinkers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :document_linkers, id: :uuid do |t|
+      t.references :job_application, null: false, foreign_key: true, type: :uuid
+      t.references :supporting_document, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/job_tracker/db/schema.rb
+++ b/job_tracker/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_06_233047) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_20_215140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,6 +41,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_06_233047) do
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "document_linkers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "job_application_id", null: false
+    t.uuid "supporting_document_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_application_id"], name: "index_document_linkers_on_job_application_id"
+    t.index ["supporting_document_id"], name: "index_document_linkers_on_supporting_document_id"
   end
 
   create_table "employers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -75,15 +84,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_06_233047) do
 
   create_table "supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
-    t.uuid "job_application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["job_application_id"], name: "index_supporting_documents_on_job_application_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "document_linkers", "job_applications"
+  add_foreign_key "document_linkers", "supporting_documents"
   add_foreign_key "job_applications", "employers"
   add_foreign_key "job_descriptions", "job_applications"
-  add_foreign_key "supporting_documents", "job_applications"
 end

--- a/job_tracker/spec/factories/document_linkers.rb
+++ b/job_tracker/spec/factories/document_linkers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :document_linker do
+    job_application { nil }
+    supporting_document { nil }
+  end
+end

--- a/job_tracker/spec/factories/supporting_documents.rb
+++ b/job_tracker/spec/factories/supporting_documents.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :supporting_document do
     name { "" }
-    job_application { nil }
+
+    # TODO: figure out a way to generate these 
   end
 end

--- a/job_tracker/spec/models/supporting_document_spec.rb
+++ b/job_tracker/spec/models/supporting_document_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe SupportingDocument, type: :model do
   let(:job_application) { create(:job_application, employer: employer) }
   let(:supporting_document) { 
     create(:supporting_document, 
-      job_application: job_application,
       name: "Resume",
       document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf")
     )
   }
+  let!(:document_linker) {create(:document_linker, job_application:, supporting_document:)}
 
 
   describe 'associations' do
-    context 'belongs_to' do
-      it "belongs to job_application" do
-        expect(supporting_document.job_application).to eq(job_application)
+    context 'has_many' do
+      it "has a document_linker" do
+        expect(supporting_document.document_linkers.first).to_not be_nil
       end
     end
 

--- a/job_tracker/spec/requests/supporting_documents_spec.rb
+++ b/job_tracker/spec/requests/supporting_documents_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "/supporting_documents", type: :request do
     {
       name: "Resume",
       document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf"),
-      job_application_id: job_application.id
+      job_application_ids: [job_application.id]
     }
   }
 
@@ -32,7 +32,7 @@ RSpec.describe "/supporting_documents", type: :request do
     {
       name: nil,
       document: nil,
-      job_application_id: nil
+      job_application_ids: []
     }
   }
 
@@ -103,7 +103,7 @@ RSpec.describe "/supporting_documents", type: :request do
         {
           name: "Cover Letter",
           document: Rack::Test::UploadedFile.new("spec/fixtures/files/cover_letter.pdf", "application/pdf"),
-          job_application_id: job_application.id
+          job_application_ids: [job_application.id]
         }
       }
 

--- a/job_tracker/spec/views/supporting_documents/edit.html.erb_spec.rb
+++ b/job_tracker/spec/views/supporting_documents/edit.html.erb_spec.rb
@@ -4,15 +4,12 @@ RSpec.describe "supporting_documents/edit", type: :view do
   let(:employer) { Employer.create!(name: "Employer") }
   let(:job_application) {create(:job_application, employer: employer)}
 
-  let(:supporting_document) {
-    SupportingDocument.create!(
+  let(:supporting_document) {SupportingDocument.create!(
       name: "Resume",
-      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf"),
-      job_application: job_application
-    )
-  }
+      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf")
+    )}
 
-  before(:each) do
+  before do
     assign(:supporting_document, supporting_document)
   end
 
@@ -25,7 +22,7 @@ RSpec.describe "supporting_documents/edit", type: :view do
 
       assert_select "input[name=?]", "supporting_document[document]"
 
-      assert_select "select[name=?]", "supporting_document[job_application_id]"
+      assert_select "input[name=?]", "supporting_document[job_application_ids][]"
     end
   end
 end

--- a/job_tracker/spec/views/supporting_documents/index.html.erb_spec.rb
+++ b/job_tracker/spec/views/supporting_documents/index.html.erb_spec.rb
@@ -3,27 +3,25 @@ require 'rails_helper'
 RSpec.describe "supporting_documents/index", type: :view do
   let(:employer) { create(:employer) }
   let(:job_application) { create(:job_application, employer: employer) }
+  let(:supporting_document1) { SupportingDocument.create!(
+      name: "Resume",
+      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf")
+    )}
 
+  let(:supporting_document2) { SupportingDocument.create!(
+      name: "Cover letter",
+      document: Rack::Test::UploadedFile.new("spec/fixtures/files/cover_letter.pdf", "application/pdf")
+    )}
+  
   before do
-    assign(:supporting_documents, [
-      SupportingDocument.create!(
-        name: "Resume",
-        document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf"),
-        job_application: job_application
-      ),
-      SupportingDocument.create!(
-        name: "Cover letter",
-        document: Rack::Test::UploadedFile.new("spec/fixtures/files/cover_letter.pdf", "application/pdf"),
-        job_application: job_application
-      )
-    ])
+    assign(:supporting_documents, [supporting_document1, supporting_document2])
   end
 
   it "renders a list of supporting_documents" do
     render
     
     assert_select "div>h2", text: Regexp.new("Name:\n*+".to_s), count: 2
-    assert_select "div>p", text: Regexp.new("Job application:\n*+".to_s), count: 2
+    assert_select "div>p", text: Regexp.new("Job applications:\n*+".to_s), count: 2
     assert_select "div>p", text: Regexp.new("Document:*+".to_s), count: 2
   end
 end

--- a/job_tracker/spec/views/supporting_documents/new.html.erb_spec.rb
+++ b/job_tracker/spec/views/supporting_documents/new.html.erb_spec.rb
@@ -3,25 +3,26 @@ require 'rails_helper'
 RSpec.describe "supporting_documents/new", type: :view do
   let(:employer) { create(:employer) }
   let(:job_application) { create(:job_application, employer: employer) }
+  let(:supporting_document) {SupportingDocument.create!(
+      name: "Resume",
+      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf")
+    )}
 
   before do
-    assign(:supporting_document, SupportingDocument.new(
-      name: "Resume",
-      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf"),
-      job_application: job_application
-    ))
+    assign(:supporting_document, supporting_document)
   end
 
   it "renders new supporting_document form" do
     render
 
-    assert_select "form[action=?][method=?]", supporting_documents_path, "post" do
+    assert_select "form[action=?][method=?]", "#{supporting_documents_path}/#{supporting_document.id}", "post" do
 
       assert_select "input[name=?]", "supporting_document[name]"
 
       assert_select "input[name=?]", "supporting_document[document]"
 
-      assert_select "select[name=?]", "supporting_document[job_application_id]"
+      assert_select "input[name=?]", "supporting_document[job_application_ids][]"
     end
+
   end
 end

--- a/job_tracker/spec/views/supporting_documents/show.html.erb_spec.rb
+++ b/job_tracker/spec/views/supporting_documents/show.html.erb_spec.rb
@@ -3,19 +3,21 @@ require 'rails_helper'
 RSpec.describe "supporting_documents/show", type: :view do
   let(:employer) { Employer.create!(name: "MyString") }
   let(:job_application) { JobApplication.create!(employer: employer) }
-
-  before(:each) do
-    assign(:supporting_document, SupportingDocument.create!(
+  let(:supporting_document) {SupportingDocument.create!(
       name: "Resume",
-      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf"),
-      job_application: job_application
-    ))
+      document: Rack::Test::UploadedFile.new("spec/fixtures/files/resume.pdf", "application/pdf")
+    )}
+  # let(:document_linker) { DocumentLinker.create!( job_application:,supporting_document:) }
+
+  before do
+    assign(:supporting_document, supporting_document)
   end
+
 
   it "renders attributes in <p>" do
     render
     expect(rendered).to match(/Name/)
     expect(rendered).to match(/Document/)
-    expect(rendered).to match(/Job application/)
+    expect(rendered).to match(/Job applications/)
   end
 end


### PR DESCRIPTION
### What

1. Model to act as intermediary / Join Table for the many-to-many relation between `job_applications` and `supporting_documents`
2. Migration for the described model
3. Existing model updates to work with the new intermediary
4. Existing form and display updates to work with new intermediary 

### Why

Turns out using `has_many` and/or 'belongs_to' creates an unwanted relationship between the applications and documents. The man-in-the-middle class allows for a common document to now be **shared** with multiple applications. \
\
The `supporting_document` form now uses check boxes to select multiple applications. The model #show also displays all the applications it's attached to.  \
\
The `job_application` #show **_continues_** to displays all the documents associated and now works with the intermediary linker.

### TODO / Next Steps

- Validations
- Double check destroy works correctly
- Move `linker.create!` Out of the controller and into a Form.object for `supporting_document`
- Factory bot for `supporting_document`
- `document_linker` specs